### PR TITLE
WIP: Feat/distributions

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,26 @@
+"""Common fixtures"""
+import pytest
+import scipy
+from scipy.stats._distr_params import distcont, distdiscrete
+
+from xrrandom.stats import _excluded_distr
+from xrrandom.scipy_stats_gen import distribution_kind
+
+distcont = dict(distcont)
+distdiscrete = dict(distdiscrete)
+
+scipy_distributions = []
+for name, distr in scipy.stats.__dict__.items():
+    if name in _excluded_distr:
+        continue
+    try:
+        kind = distribution_kind(distr)
+    except ValueError:
+        continue
+    scipy_distributions.append(
+        {'name': name, 'distr': distr, 'kind': kind,
+         'params': distcont.get(name) if kind == 'continuous' else distdiscrete.get(name)})
+
+@pytest.fixture(scope='session', params=scipy_distributions)
+def stats_distr(request):
+    return request.param

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ distcont = dict(distcont)
 distdiscrete = dict(distdiscrete)
 
 scipy_distributions = []
-for name, distr in scipy.stats.__dict__.items():
+for name, distr in vars(scipy.stats).items():
     if name in _excluded_distr:
         continue
     try:

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -1,0 +1,37 @@
+import scipy
+import numpy as np
+import xarray as xr
+
+import xrrandom
+from xrrandom import sample
+
+def test_distribution_exists(stats_distr):
+    assert hasattr(xrrandom.distributions, stats_distr['name'])
+
+
+def test_rvs_pdf(stats_distr, loc=0.5, scale=0.1):
+    scipy_distr = stats_distr['distr']
+    shape_params = stats_distr['params']
+
+    xr_distr = getattr(xrrandom.distributions, stats_distr['name'])
+
+    if stats_distr['kind'] == 'continuous':
+        x = np.linspace(max(scipy_distr.a, -100), min(scipy_distr.b, 100), 1000)
+        shape_params = list(shape_params) + [loc, scale]
+        method = 'pdf'
+    elif stats_distr['kind'] == 'discrete':
+        x = np.arange(max(scipy_distr.a, -100), min(scipy_distr.b + 1, 101))
+        method = 'pmf'
+    else:
+        raise ValueError(f'unknown kind {stats_distr["kind"]}')
+
+    xr_shape_params = [xr.DataArray(sp) for sp in shape_params]
+
+    N = 100
+    np.random.seed(0)
+    scipy_rvs = scipy_distr(*shape_params).rvs(size=N)
+    np.random.seed(0)
+    xr_rvs = xr_distr(*xr_shape_params)
+
+    assert np.allclose(scipy_rvs, sample(xr_rvs, N), equal_nan=True)
+    assert isinstance(xr_rvs, xr.DataArray)

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -1,3 +1,4 @@
+import pytest
 import scipy
 import numpy as np
 import xarray as xr
@@ -35,3 +36,13 @@ def test_rvs_pdf(stats_distr, loc=0.5, scale=0.1):
 
     assert np.allclose(scipy_rvs, sample(xr_rvs, N), equal_nan=True)
     assert isinstance(xr_rvs, xr.DataArray)
+
+
+def test_required_shape_params():
+
+    # shape parameters other than loc and scale are required
+    with pytest.raises(TypeError):
+        xrrandom.distributions.gamma()
+
+    # loc and scale have defaults -> this is ok
+    xrrandom.distributions.gamma(a=3)

--- a/tests/test_scipy_stats.py
+++ b/tests/test_scipy_stats.py
@@ -1,0 +1,46 @@
+import numpy as np
+import xarray as xr
+
+import xrrandom
+
+
+def test_distribution_kind(stats_distr):
+    assert getattr(xrrandom.stats, stats_distr['name'])._kind == stats_distr['kind']
+
+
+def test_rvs_pdf(stats_distr, loc=0.5, scale=0.1):
+    scipy_distr = stats_distr['distr']
+    shape_params = stats_distr['params']
+
+    xr_distr = getattr(xrrandom.stats, stats_distr['name'])
+
+    if stats_distr['kind'] == 'continuous':
+        x = np.linspace(max(scipy_distr.a, -100), min(scipy_distr.b, 100), 1000)
+        shape_params = list(shape_params) + [loc, scale]
+        method = 'pdf'
+    elif stats_distr['kind'] == 'discrete':
+        x = np.arange(max(scipy_distr.a, -100), min(scipy_distr.b + 1, 101))
+        method = 'pmf'
+    else:
+        raise ValueError(f'unknown kind {stats_distr["kind"]}')
+
+    xr_shape_params = [xr.DataArray(sp) for sp in shape_params]
+
+    frozen_scipy = scipy_distr(*shape_params)
+    scipy_pdf = getattr(frozen_scipy, method)(x)
+
+    assert np.allclose(scipy_pdf, getattr(xr_distr, method)(x, *xr_shape_params), equal_nan=True)
+    assert np.allclose(scipy_pdf, getattr(xr_distr(*xr_shape_params), method)(x), equal_nan=True)  # frozen
+
+    N = 100
+    np.random.seed(0)
+    scipy_rvs = frozen_scipy.rvs(size=N)
+    np.random.seed(0)
+    xr_rvs = xr_distr.rvs(*xr_shape_params, samples=N)
+    assert np.allclose(scipy_rvs, xr_rvs, equal_nan=True)
+    assert isinstance(xr_rvs, xr.DataArray)
+
+    np.random.seed(0)
+    xr_rvs = xr_distr(*xr_shape_params).rvs(samples=N)
+    assert np.allclose(scipy_rvs, xr_rvs, equal_nan=True)
+    assert isinstance(xr_rvs, xr.DataArray)

--- a/tests/test_scipy_stats.py
+++ b/tests/test_scipy_stats.py
@@ -1,3 +1,4 @@
+import pytest
 import numpy as np
 import xarray as xr
 
@@ -44,3 +45,13 @@ def test_rvs_pdf(stats_distr, loc=0.5, scale=0.1):
     xr_rvs = xr_distr(*xr_shape_params).rvs(samples=N)
     assert np.allclose(scipy_rvs, xr_rvs, equal_nan=True)
     assert isinstance(xr_rvs, xr.DataArray)
+
+
+def test_required_shape_params():
+
+    # shape parameters other than loc and scale are required
+    with pytest.raises(TypeError):
+        xrrandom.stats.gamma()
+
+    # loc and scale have defaults -> this is ok
+    xrrandom.stats.gamma(a=3)

--- a/xrrandom/__init__.py
+++ b/xrrandom/__init__.py
@@ -1,5 +1,5 @@
 from .scipy_stats_sampling import sample_distribution, virtually_sample_distribution
 from .sampling import change_virtual_samples
 from .arch_boostrap_gen import bootstrap_samples
-from . import distributions
-from .distributions import sample
+from . import stats
+from .stats import sample

--- a/xrrandom/__init__.py
+++ b/xrrandom/__init__.py
@@ -1,5 +1,4 @@
 from .scipy_stats_sampling import sample_distribution, virtually_sample_distribution
-from .sampling import change_virtual_samples
+from .sampling import change_virtual_samples, sample
 from .arch_boostrap_gen import bootstrap_samples
 from . import stats
-from .stats import sample

--- a/xrrandom/__init__.py
+++ b/xrrandom/__init__.py
@@ -2,3 +2,4 @@ from .scipy_stats_sampling import sample_distribution, virtually_sample_distribu
 from .sampling import change_virtual_samples, sample
 from .arch_boostrap_gen import bootstrap_samples
 from . import stats
+from . import distributions

--- a/xrrandom/__init__.py
+++ b/xrrandom/__init__.py
@@ -1,3 +1,5 @@
 from .scipy_stats_sampling import sample_distribution, virtually_sample_distribution
 from .sampling import change_virtual_samples
 from .arch_boostrap_gen import bootstrap_samples
+from . import distributions
+from .distributions import sample

--- a/xrrandom/distributions.py
+++ b/xrrandom/distributions.py
@@ -1,0 +1,122 @@
+import dask.array as da
+
+from .scipy_stats_sampling import sample_distribution, virtually_sample_distribution
+from .sampling import change_virtual_samples
+
+def from_scipy(stats_distribution, *args, samples=1, sample_chunksize=None, sample=False, **kwargs):
+    """Create a virtual distribution into dask from scipy.stats with parameters given as xarray objects
+
+    For the virtual sampling idea look at :py:func`xrrandom.sampling.generate_virtual_samples``
+
+    Parameters
+    ----------
+    stats_distribution : str or scipy.stats.rv_continuous or scipy.stats.rv_discrete
+        name of a scipy.sats distribution or a specific distribution object
+    samples : int, optional
+        number of samples to draw, defaults to 1
+    sample_chunksize : ints, optional
+        if given, the sample dimension will have this chunksize but the number of samples cannot be later changed
+    sample : bool, optional
+        directly sample from the distribution (True) or return virtual distribution (False), default False
+    *args, **kwargs : scalar or  array_like or xarray objects
+        positional and keyword arguments to the rvs() method of *stats_distribution*
+
+
+    Returns
+    -------
+    samples : xarray object
+        xarray object representing the given distribution or samples drawn from it, 
+        with arguments broadcasted according to dimensions and a new dimension 'sample' with size *samples*
+        if sample==False the data will be a dask Array
+
+    Raises
+    ------
+    ValueError
+        if the *stats_distribution* cannot be found or is not a valid distribution object
+    """
+    if sample:
+        # TODO: warn or raise exception if sample_chunksize is not None?
+        return sample_distribution(stats_distribution, samples, *args, **kwargs)
+    else:
+        return virtually_sample_distribution(stats_distribution, samples, *args, 
+                                             sample_chunksize=sample_chunksize, **kwargs)
+
+def sample(distribution, samples=None):
+    """Sample virtual distribution
+
+    Parameters
+    ----------
+    distribution : xarray.DataArray
+        xarray representing the virtual distribution
+    samples : int, optional
+        number of samples to be generated, defaults to the number of samples specified
+        when creating the distribution
+
+
+    Returns
+    -------
+    samples : xarray object
+        samples from the given distribution
+    """
+    if not isinstance(distribution.data, da.Array):
+        raise TypeError('`distribution` must be dask xarray')
+    if samples is not None:
+        distribution = change_virtual_samples(distribution, new_sample_count=samples)
+    
+    return distribution.compute()
+
+
+def normal(loc=0, scale=1, samples=1, sample_chunksize=None, sample=False):
+    """Generate (virtual) samples from the normal distribution
+    
+    Parameters
+    ----------
+    loc : scalar or  array_like or xarray objects, optional
+        mean of the normal distribution, default value is 0
+    scale : scalar or  array_like or xarray objects, optional
+        standard derivation of the normal distribution, default value is 1
+    samples : int, optional
+        set the default number of samples, default value is 1
+    sample_chunksize : int, optional
+        if given, the sample dimension will have this chunksize but the number of samples cannot be later changed
+    sample : bool, optional
+        directly sample from the distribution (True) or return virtual distribution (False), default False
+    
+
+    Returns
+    -------
+    samples : xarray object
+        xarray object representing the given distribution or samples drawn from it, 
+        with arguments broadcasted according to dimensions and a new dimension 'sample' with size *samples*
+        if sample==False the data will be a dask Array
+    """
+    return from_scipy('norm', loc=loc, scale=scale, samples=samples, sample_chunksize=sample_chunksize, sample=sample)
+
+
+def gamma(a, loc=0, scale=1, samples=1, sample_chunksize=0, sample=False):
+    """Generate (virtual) samples from the gamma distribution
+
+    Parameters
+    ----------
+    a : scalar or  array_like or xarray objects, optional
+        shape parameter of the gamma distribution
+    loc : scalar or  array_like or xarray objects, optional
+        mean of the normal distribution, default value is 0
+    scale : scalar or  array_like or xarray objects, optional
+        standard derivation of the normal distribution, default value is 1
+    samples : int, optional
+        set the default number of samples, default value is 1
+    sample_chunksize : int, optional
+        if given, the sample dimension will have this chunksize but the number of samples cannot be later changed
+    sample : bool, optional
+        directly sample from the distribution (True) or return virtual distribution (False), default False
+    
+
+    Returns
+    -------
+    samples : xarray object
+        xarray object representing the given distribution or samples drawn from it, 
+        with arguments broadcasted according to dimensions and a new dimension 'sample' with size *samples*
+        if sample==False the data will be a dask Array
+    """
+    return from_scipy('gamma', a=a, loc=loc, scale=scale, samples=samples, sample_chunksize=sample_chunksize, sample=sample)

--- a/xrrandom/distributions.py
+++ b/xrrandom/distributions.py
@@ -69,5 +69,5 @@ def _register_virtual_rv(name, distr):
     globals()[name] = gen_class(distr)
 
 # augment this module by all distributions in the scipy.stats
-for name, distr in stats.__dict__.items():
+for name, distr in vars(stats).items():
     _register_virtual_rv(name, distr)

--- a/xrrandom/distributions.py
+++ b/xrrandom/distributions.py
@@ -1,0 +1,55 @@
+import scipy.stats as stats
+
+from .scipy_stats_sampling import virtually_sample_distribution
+
+class VirtualDistribution:
+    """Representation of scipy.stats distribution using virtual samples.
+    
+    The location (``loc``) keyword specifies the mean.
+    The scale (``scale``) keyword specifies the standard deviation
+    Other shape parameters specific for the distribution are passed to 
+    the scipy distribution.
+
+    The size of the output array is determined by broadcasting the shapes of the
+    input arrays, scipy.stats ``shape`` parameter is ignored.
+
+    The ``samples`` parameter determines how many random samples will be drawn,
+    can be changed later using ``xrrandom.sample`` or ``xrrandom.change_virtual_samples``.
+
+    For the virtual sampling idea look at :py:func`xrrandom.sampling.generate_virtual_samples``
+    """   
+
+    def __init__(self, distr):
+        self._distr = distr
+        self.__doc__ = distr.__doc__.split('\n')[0]
+
+    def __call__(self, *args, samples=1, virtual=None, sample_chunksize=None, **kwargs):
+        """Create virtually sampled distribution with the given shape.
+        
+        Parameters
+        ----------
+        args, kwargs: xarray.DataArray
+            The shape parameter(s) for the distribution. Should include all the non-optional arguments,
+            may include ``loc`` and ``scale``.
+        samples: int, optional
+            Number of random samples (default: 1)        
+        sample_chinksize: ints, optional
+            Chunksize of the sample dimension (default: None). If given, the number of samples cannot be later changed. 
+            Used only if `virtual` is True.
+        
+        Returns
+        -------
+        distr: xarray.DataArray
+            DataArray wrapping delayed Dask array. Samples obtained by `distr.values` 
+            will be different on each call. Use `xrrandom.change_virtual_samples` or
+            `xrrandom.sample` to change the number of virtual samples.
+        """        
+        
+        return virtually_sample_distribution(self._distr, samples=samples, *args, 
+                                             sample_chunksize=sample_chunksize, **kwargs)
+
+
+# augment this module by all distributions in the scipy.stats
+for name, distr in stats.__dict__.items():
+    if isinstance(distr, (stats.rv_continuous, stats.rv_discrete)):
+        globals()[name] = VirtualDistribution(distr)                                             

--- a/xrrandom/distributions.py
+++ b/xrrandom/distributions.py
@@ -1,7 +1,8 @@
 import scipy.stats as stats
 
 from .scipy_stats_sampling import virtually_sample_distribution
-from .scipy_stats_gen import distribution_kind
+from .scipy_stats_gen import distribution_kind, distribution_parameters
+from .stats import _shape_params_to_doc, _wrap_stats_func
 
 class VirtualDistribution:
     """Representation of scipy.stats distribution using virtual samples.
@@ -11,50 +12,62 @@ class VirtualDistribution:
     Other shape parameters specific for the distribution are passed to 
     the scipy distribution.
 
-    The size of the output array is determined by broadcasting the shapes of the
-    input arrays, scipy.stats ``shape`` parameter is ignored.
+    The size of the output array is determined by broadcasting the shapes of 
+    the input arrays, scipy.stats ``shape`` parameter is ignored.
 
     The ``samples`` parameter determines how many random samples will be drawn,
-    can be changed later using ``xrrandom.sample`` or ``xrrandom.change_virtual_samples``.
+    can be changed later using ``xrrandom.sample`` or 
+    ``xrrandom.change_virtual_samples``.
 
-    For the virtual sampling idea look at :py:func`xrrandom.sampling.generate_virtual_samples``
+    For the virtual sampling idea look at 
+    :py:func`xrrandom.sampling.generate_virtual_samples``
     """   
 
     def __init__(self, distr):
-        self._distr = distr
-        self.__doc__ = distr.__doc__.split('\n')[0]
+        self._distr = distr    
+        self.__doc__ = distr.__doc__.split('\n')[0]+'\n\nVirtual distribution.\n\n'
 
-    def __call__(self, *args, samples=1, virtual=None, sample_chunksize=None, **kwargs):
+    def _call(self, *args, samples=1, virtual=None, sample_chunksize=None, **kwargs):
         """Create virtually sampled distribution with the given shape.
         
         Parameters
         ----------
-        args, kwargs: xarray.DataArray
-            The shape parameter(s) for the distribution. Should include all the non-optional arguments,
-            may include ``loc`` and ``scale``.
+        {shape_parameters}
         samples: int, optional
             Number of random samples (default: 1)        
         sample_chinksize: ints, optional
-            Chunksize of the sample dimension (default: None). If given, the number of samples cannot be later changed. 
-            Used only if `virtual` is True.
+            Chunksize of the sample dimension (default: None). If given, the 
+            number of samples cannot be later changed. Used only if `virtual`
+            is True.
         
         Returns
         -------
         distr: xarray.DataArray
-            DataArray wrapping delayed Dask array. Samples obtained by `distr.values` 
-            will be different on each call. Use `xrrandom.change_virtual_samples` or
-            `xrrandom.sample` to change the number of virtual samples.
+            DataArray wrapping delayed Dask array. Samples obtained by 
+            `distr.values` will be different on each call. Use 
+            `xrrandom.change_virtual_samples` or`xrrandom.sample` to 
+            change the number of virtual samples.
         """        
-        
-        return virtually_sample_distribution(self._distr, samples=samples, *args, 
-                                             sample_chunksize=sample_chunksize, **kwargs)
+
+        return virtually_sample_distribution(self._distr, samples, *args,
+                                             sample_chunksize=sample_chunksize,
+                                             **kwargs)
 
 
-# augment this module by all distributions in the scipy.stats
-for name, distr in stats.__dict__.items():
+def _register_virtual_rv(name, distr):
     try:
         distribution_kind(distr)
     except ValueError:
-        continue
-    else:    
-        globals()[name] = VirtualDistribution(distr)                                             
+        return
+
+    gen_class = type(f'{name}_gen', (VirtualDistribution,), {})
+    setattr(gen_class, '__call__', _wrap_stats_func(distr, gen_class._call,
+                                                    is_stats_method=False,
+                                                    all_pos_or_kw=True))
+
+    globals()[f'_{name}_gen'] = gen_class
+    globals()[name] = gen_class(distr)
+
+# augment this module by all distributions in the scipy.stats
+for name, distr in stats.__dict__.items():
+    _register_virtual_rv(name, distr)

--- a/xrrandom/distributions.py
+++ b/xrrandom/distributions.py
@@ -1,6 +1,7 @@
 import scipy.stats as stats
 
 from .scipy_stats_sampling import virtually_sample_distribution
+from .scipy_stats_gen import distribution_kind
 
 class VirtualDistribution:
     """Representation of scipy.stats distribution using virtual samples.
@@ -51,5 +52,9 @@ class VirtualDistribution:
 
 # augment this module by all distributions in the scipy.stats
 for name, distr in stats.__dict__.items():
-    if isinstance(distr, (stats.rv_continuous, stats.rv_discrete)):
+    try:
+        distribution_kind(distr)
+    except ValueError:
+        continue
+    else:    
         globals()[name] = VirtualDistribution(distr)                                             

--- a/xrrandom/sampling.py
+++ b/xrrandom/sampling.py
@@ -149,3 +149,28 @@ def change_virtual_samples(virtually_sampled_darray, new_sample_count:int):
     )
     return new_darray
 
+
+def sample(distr, samples=None):
+    """Sample virtual distribution
+
+    Parameters
+    ----------
+    distr : xarray.DataArray
+        xarray representing the virtual distribution
+    samples : int, optional
+        number of samples to be generated, defaults to the number of samples specified
+        when creating the distribution
+
+
+    Returns
+    -------
+    samples : xarray object
+        samples from the given distribution
+    """
+    if not isinstance(distr.data, da.Array):
+        raise TypeError('`distribution` must be dask xarray')
+    if samples is not None:
+        distr = change_virtual_samples(distr, new_sample_count=samples)
+    
+    return distr.compute()
+

--- a/xrrandom/scipy_stats_gen.py
+++ b/xrrandom/scipy_stats_gen.py
@@ -26,7 +26,7 @@ def distribution_kind(stats_distribution):
     elif isinstance(stats_distribution, stats.rv_discrete):
         return 'discrete'
     else:
-        raise ValueError('stats_distribution bust be either rv_continuous or rv_discrete')
+        raise ValueError('stats_distribution must be either rv_continuous or rv_discrete')
 
 
 _general_params = {

--- a/xrrandom/scipy_stats_sampling.py
+++ b/xrrandom/scipy_stats_sampling.py
@@ -11,24 +11,29 @@ _output_dtypes = {
 }
 
 
-def _rvs_gen_args(stats_distribution, *args, **kwargs):
-    stats_distribution = get_stats_distribution(stats_distribution)
-    output_dtype = _output_dtypes[distribution_kind(stats_distribution)]
-    rvs_gen = sample_dim_rvs_factory(stats_distribution)
-    param_names = distribution_parameters(stats_distribution)
-    # ugly args, kwargs parsing do to inconvenient scipy.stats convention
+def _parse_scipy_args(param_names, *args, **kwargs):
+    # ugly args, kwargs parsing due to inconvenient scipy.stats convention
     args_full = []
     args = list(args)
     for p in param_names:
         if p in kwargs:
             args_full.append(kwargs[p])
-        elif len(args) == 0:    # already empty, need defaults
+        elif len(args) == 0:  # already empty, need defaults
             if p == 'loc':
                 args_full.append(0)
             elif p == 'scale':
                 args_full.append(1)
         else:
             args_full.append(args.pop(0))
+    return args_full
+
+
+def _rvs_gen_args(stats_distribution, *args, **kwargs):
+    stats_distribution = get_stats_distribution(stats_distribution)
+    output_dtype = _output_dtypes[distribution_kind(stats_distribution)]
+    rvs_gen = sample_dim_rvs_factory(stats_distribution)
+    param_names = distribution_parameters(stats_distribution)
+    args_full = _parse_scipy_args(param_names, *args, **kwargs)
     return rvs_gen, args_full, output_dtype
 
 

--- a/xrrandom/scipy_stats_sampling.py
+++ b/xrrandom/scipy_stats_sampling.py
@@ -15,6 +15,7 @@ def _parse_scipy_args(param_names, *args, **kwargs):
     # ugly args, kwargs parsing due to inconvenient scipy.stats convention
     args_full = []
     args = list(args)
+    missing = []
     for p in param_names:
         if p in kwargs:
             args_full.append(kwargs[p])
@@ -23,8 +24,14 @@ def _parse_scipy_args(param_names, *args, **kwargs):
                 args_full.append(0)
             elif p == 'scale':
                 args_full.append(1)
+            else:
+                missing.append(f"'{p}'")
         else:
             args_full.append(args.pop(0))
+
+    if len(missing) > 0:
+        raise TypeError(f'missing shape parameter(s): {", ".join(missing)}')
+
     return args_full
 
 

--- a/xrrandom/stats.py
+++ b/xrrandom/stats.py
@@ -107,7 +107,7 @@ class ScipyStatsWrapper:
         -------
         virtual_samples: xarray.DataArray
             DataArray wrapping delayed Dask array. Samples obtained by `virtual_samples.values` will be
-            different on each call. Use `xrrandom.change_virtual_samples` or`xrrandom.distributions.sample` 
+            different on each call. Use `xrrandom.change_virtual_samples` or`xrrandom.sample` 
             to change number of samples.
         """
         return self.rvs(virtual=True, sample_chunksize=sample_chunksize)        

--- a/xrrandom/stats.py
+++ b/xrrandom/stats.py
@@ -1,35 +1,8 @@
-import functools
-import inspect
 import dask.array as da
 import scipy.stats as stats
 
 from .scipy_stats_sampling import sample_distribution, virtually_sample_distribution
 from .sampling import change_virtual_samples
-
-
-def sample(distribution, samples=None):
-    """Sample virtual distribution
-
-    Parameters
-    ----------
-    distribution : xarray.DataArray
-        xarray representing the virtual distribution
-    samples : int, optional
-        number of samples to be generated, defaults to the number of samples specified
-        when creating the distribution
-
-
-    Returns
-    -------
-    samples : xarray object
-        samples from the given distribution
-    """
-    if not isinstance(distribution.data, da.Array):
-        raise TypeError('`distribution` must be dask xarray')
-    if samples is not None:
-        distribution = change_virtual_samples(distribution, new_sample_count=samples)
-    
-    return distribution.compute()
 
 
 class ScipyStatsWrapper:

--- a/xrrandom/stats.py
+++ b/xrrandom/stats.py
@@ -237,64 +237,68 @@ class FrozenScipyBase:
     """    
     def __init__(self, distr, *args, samples=None, sample_chunksize=None, 
                  virtual=None, doc=None, **kwargs):
-        self.args = args
-        self.kwargs = kwargs
-        self.distr = distr
+
+        self._args = args
+        self._kwargs = kwargs
+        self._distr = distr
+        shape_params = self._distr.shape_parameters
+        # _parse_scipy_args raises TypeError if some shape parameters are missing
+        values = _parse_scipy_args(shape_params, *self._args, **self._kwargs)
+        self._shape_parameters = dict((k, v) for k, v in zip(shape_params, values))
+
         self.samples = samples
         self.sample_chunksize=sample_chunksize
         self.virtual = virtual
+
         if doc is not None:
             self.__doc__ = doc
 
     @property
     def shape_parameters(self):
-        """Shape parameters of the frozen distribution"""
-        shape_params = self.distr.shape_parameters
-        values = _parse_scipy_args(shape_params, *self.args, **self.kwargs)
-        return dict((k, v) for k, v in zip(shape_params, values))
+        return self._shape_parameters
 
     def cdf(self, x):
-        return self.distr.cdf(x, *self.args, **self.kwargs)
+        return self._distr.cdf(x, *self._args, **self._kwargs)
 
     def logcdf(self, x):
-        return self.distr.logcdf(x, *self.args, **self.kwargs)
+        return self._distr.logcdf(x, *self._args, **self._kwargs)
 
     def sf(self, x):
-        return self.distr.sf(x, *self.args, **self.kwargs)
+        return self._distr.sf(x, *self._args, **self._kwargs)
 
     def logsf(self, x):
-        return self.distr.logsf(x, *self.args, **self.kwargs)
+        return self._distr.logsf(x, *self._args, **self._kwargs)
 
     def ppf(self, q):
-        return self.distr.ppf(q, *self.args, **self.kwargs)
+        return self._distr.ppf(q, *self._args, **self._kwargs)
 
     def moment(self, n):
-        return self.distr.moment(n, *self.args, **self.kwargs)
+        return self._distr.moment(n, *self._args, **self._kwargs)
 
     def stats(self, moments='mv'):
-        return self.distr.stats(*self.args, moments=moments, **self.kwargs)
+        return self._distr.stats(*self._args, moments=moments, **self._kwargs)
 
     def entropy(self):
-        return self.distr.entropy(*self.args, **self.kwargs)
+        return self._distr.entropy(*self._args, **self._kwargs)
 
     def expect(self, func=None, lb=None, ub=None, conditional=False):
-        return self.distr.expect(*self.args, func=func, lb=lb, ub=ub, conditional=conditional,
-                                 **self.kwargs)
+        return self._distr.expect(*self._args, func=func, lb=lb, ub=ub, conditional=conditional,
+                                  **self._kwargs)
                                 
     def median(self):
-        return self.distr.median(*self.args, **self.kwargs)
+        return self._distr.median(*self._args, **self._kwargs)
 
     def mean(self):
-        return self.distr.mean(*self.args, **self.kwargs)
+        return self._distr.mean(*self._args, **self._kwargs)
 
     def std(self):
-        return self.distr.std(*self.args, **self.kwargs)
+        return self._distr.std(*self._args, **self._kwargs)
 
     def var(self):
-        return self.distr.var(*self.args, **self.kwargs)
+        return self._distr.var(*self._args, **self._kwargs)
 
     def interval(self, alpha):
-        return self.distr.interval(alpha, *self.args, **self.kwargs)
+        return self._distr.interval(alpha, *self._args, **self._kwargs)
 
     def rvs(self, samples=None, virtual=None, sample_chunksize=None):
         """Sample frozen distribution.
@@ -322,17 +326,17 @@ class FrozenScipyBase:
             to change number of virtual samples.
         """
         samples = samples or self.samples or 1
-        virtual = virtual or self.virtual or self.distr._default_virtual
+        virtual = virtual or self.virtual or self._distr._default_virtual
         sample_chunksize = sample_chunksize or self.sample_chunksize
 
-        return self.distr.rvs(*self.args, samples=samples, virtual=virtual, sample_chunksizes=sample_chunksize, **self.kwargs)
+        return self._distr.rvs(*self._args, samples=samples, virtual=virtual, sample_chunksizes=sample_chunksize, **self._kwargs)
 
     def __repr__(self):
         func_args = ', '.join(f'{k}={v}' for k, v in (list(self.shape_parameters.items())+
                                                            [('samples', self.samples),
                                                             ('sample_chunksize', self.sample_chunksize),
                                                             ('virtual', self.virtual)]))
-        distr_name = self.distr.__class__.__name__
+        distr_name = self._distr.__class__.__name__
         if distr_name.endswith('_gen'):
             distr_name = distr_name[:-4]
         return f'{distr_name}({func_args})'
@@ -340,18 +344,18 @@ class FrozenScipyBase:
 
 class FrozenScipyContinuous(FrozenScipyBase):    
     def pdf(self, x):
-        return self.distr.pdf(x, *self.args, **self.kwargs)
+        return self._distr.pdf(x, *self._args, **self._kwargs)
     
     def logpdf(self, x):
-        return self.distr.logpdf(x, *self.args, **self.kwargs)
+        return self._distr.logpdf(x, *self._args, **self._kwargs)
 
 
 class FrozenScipyDiscrete(FrozenScipyBase):    
     def pmf(self, k):
-        return self.distr.pmf(k, *self.args, **self.kwargs)
+        return self._distr.pmf(k, *self._args, **self._kwargs)
 
     def logpmf(self, k):
-        return self.distr.logpmf(k, *self.args, **self.kwargs)
+        return self._distr.logpmf(k, *self._args, **self._kwargs)
 
 
 def _register_rv(name, distr):

--- a/xrrandom/stats.py
+++ b/xrrandom/stats.py
@@ -9,6 +9,10 @@ from .scipy_stats_sampling import (sample_distribution,
 from .scipy_stats_gen import distribution_kind, distribution_parameters
 
 
+_excluded_distr = ['frechet_r', # deprecated, inconsistent signature of pdf: (*args, **kwargs) instead of (x, *args, **kwargs)
+                   'frechet_l', # deprecated, inconsistent signature of pdf: (*args, **kwargs) instead of (x, *args, **kwargs)
+                   ]
+
 _scipy_rv_methods = {
     'continuous': {'pdf', 'logpdf', 'fit', 'fit_loc_scale', 'nnlf'},
     'discrete': {'pmf', 'logpmf'},    
@@ -89,7 +93,6 @@ def _wrap_stats_func(stats_distribution, func, is_stats_method,
         def wrapped_method(self, *args, **kwargs):
             args = _parse_scipy_args(pos_parameters + shape_parameters, *args, **kwargs)
             args = [xr.DataArray(a) for a in args]
-            print(args)
             return xr.apply_ufunc(func, *args, output_dtypes=[output_dtype])
 
     else:
@@ -357,5 +360,7 @@ def _register_rv(name, distr):
 
 
 # augment this module by all distributions in scipy.stats
-for name, distr in stats.__dict__.items():    
+for name, distr in stats.__dict__.items():
+    if name in _excluded_distr:
+        continue
     _register_rv(name, distr)

--- a/xrrandom/stats.py
+++ b/xrrandom/stats.py
@@ -360,7 +360,7 @@ def _register_rv(name, distr):
 
 
 # augment this module by all distributions in scipy.stats
-for name, distr in stats.__dict__.items():
+for name, distr in vars(stats).items():
     if name in _excluded_distr:
         continue
     _register_rv(name, distr)

--- a/xrrandom/stats.py
+++ b/xrrandom/stats.py
@@ -208,8 +208,11 @@ class ScipyDistributionBase:
         rvs: FrozenScipyContinuous or FrozenScipyDiscrete
             Frozen version of the distribution with shape parameters fixed
         """
-        
-        return self._frozen_class(self, *args, samples=samples, virtual=virtual, sample_chunksize=sample_chunksize, **kwargs)
+
+        doc = self.__doc__.split('\n')[0] 
+        return self._frozen_class(self, *args, samples=samples, virtual=virtual, 
+                                  sample_chunksize=sample_chunksize, doc=doc,
+                                  **kwargs)
 
 
 class FrozenScipyBase:
@@ -224,13 +227,16 @@ class FrozenScipyBase:
     For the virtual sampling idea look at 
     :py:func``xrrandom.sampling.generate_virtual_samples``
     """    
-    def __init__(self, distr, *args, samples=None, sample_chunksize=None, virtual=None, **kwargs):
+    def __init__(self, distr, *args, samples=None, sample_chunksize=None, 
+                 virtual=None, doc=None, **kwargs):
         self.args = args
         self.kwargs = kwargs
         self.distr = distr
         self.samples = samples
         self.sample_chunksize=sample_chunksize
         self.virtual = virtual
+        if doc is not None:
+            self.__doc__ = doc
 
     def cdf(self, x):
         return self.distr.cdf(x, *self.args, **self.kwargs)

--- a/xrrandom/stats.py
+++ b/xrrandom/stats.py
@@ -2,7 +2,6 @@ import dask.array as da
 import scipy.stats as stats
 
 from .scipy_stats_sampling import sample_distribution, virtually_sample_distribution
-from .sampling import change_virtual_samples
 
 
 class ScipyStatsWrapper:

--- a/xrrandom/stats.py
+++ b/xrrandom/stats.py
@@ -1,8 +1,24 @@
+from functools import partial
 import dask.array as da
 import scipy.stats as stats
 
 from .scipy_stats_sampling import sample_distribution, virtually_sample_distribution
+from .scipy_stats_gen import distribution_kind
 
+_scipy_rv_methods = {
+    'continuous': {'pdf', 'logpdf', 'fit', 'fit_loc_scale', 'nnlf'},
+    'discrete': {'pmf', 'logpmf'},    
+}
+
+_common_scipy_rv_methods = {'cdf', 'logcdf', 'sf', 'logsf', 'ppf', 
+                            'moment', 'stats', 'entropy', 'expect', 'median',
+                            'mean', 'std', 'var', 'interval'}
+
+def _bind_stats_method(dest, source, method):
+    return getattr(source, method).__get__(dest)
+
+def _bind_frozen_method(dest, source, method, *args, **kwargs):
+    return partial(getattr(source, method).__get__(dest), *args, **kwargs)
 
 class ScipyDistribution:
     """Xarray wrapper for scipy.stats distribution. 
@@ -25,11 +41,13 @@ class ScipyDistribution:
     For the virtual sampling idea look at :py:func`xrrandom.sampling.generate_virtual_samples``
     """
 
-    _default_virtual = False
+    _default_virtual = False    
 
     def __init__(self, distr):
         self._distr = distr
-        self.__doc__ = distr.__doc__.split('\n')[0]
+        self.__doc__ = distr.__doc__.split('\n')[0]        
+        for method in _common_scipy_rv_methods | _scipy_rv_methods[distribution_kind(distr)]:
+            setattr(self, method, _bind_stats_method(self, distr, method))    
 
     def rvs(self, *args, samples=1, virtual=None, sample_chunksize=None, **kwargs):
         """Sample the given distribution.
@@ -106,6 +124,9 @@ class FrozenScipyDistribution:
         self.samples = samples
         self.sample_chunksize=sample_chunksize
         self.virtual = virtual
+
+        for method in _common_scipy_rv_methods | _scipy_rv_methods[distribution_kind(distr._distr)]:
+            setattr(self, method, _bind_frozen_method(self, distr, method))
 
     def rvs(self, samples=None, virtual=None, sample_chunksize=None):
         """Sample frozen distribution.

--- a/xrrandom/stats.py
+++ b/xrrandom/stats.py
@@ -4,7 +4,7 @@ import scipy.stats as stats
 from .scipy_stats_sampling import sample_distribution, virtually_sample_distribution
 
 
-class ScipyStatsWrapper:
+class ScipyDistribution:
     """Xarray wrapper for scipy.stats distribution. 
     
     The location (``loc``) keyword specifies the mean.
@@ -17,17 +17,19 @@ class ScipyStatsWrapper:
 
     The ``samples`` parameter determines how many random samples will be drawn.
 
-    Call to the method ``rvs`` returns static array of randomly drawn samples, direct
-    call to this instance returns virtually sampled distribution.
+    It contains the same methods as scipy.stats distribution, such as ``rvs`` to draw
+    random samples. Direct call creates frozen distribution. 
+
+    Use ``rvs`` with parameter ``virtual=True`` to obtain virtually sampled distribution.
 
     For the virtual sampling idea look at :py:func`xrrandom.sampling.generate_virtual_samples``
     """
 
     _default_virtual = False
 
-    def __init__(self, stats_distribution):
-        self._stats_distribution = stats_distribution
-        self.__doc__ = stats_distribution.__doc__.split('\n')[0]
+    def __init__(self, distr):
+        self._distr = distr
+        self.__doc__ = distr.__doc__.split('\n')[0]
 
     def rvs(self, *args, samples=1, virtual=None, sample_chunksize=None, **kwargs):
         """Sample the given distribution.
@@ -48,43 +50,93 @@ class ScipyStatsWrapper:
         Returns
         -------
         rvs: xarray.DataArray
-            Random samples from the given distribution. Standard static array if virtual is False,
-            otherwise DataArray wrapping delayed Dask array. In such case samples obtained by `virtual_samples.values` 
-            will be different on each call. Use `xrrandom.change_virtual_samples` or`xrrandom.distributions.sample` 
-            to change number of virtual samples.
+            Random samples from the given distribution. Standard static array 
+            if virtual is False,otherwise DataArray wrapping delayed Dask array.
+            In such case samples obtained by `virtual_samples.values` will be 
+            different on each call. Use `xrrandom.change_virtual_samples` or
+            `xrrandom.distributions.sample` to change number of virtual samples.
         """
         virtual = virtual or self._default_virtual
 
         if virtual:
-            return virtually_sample_distribution(self._stats_distribution, samples=samples, *args, 
+            return virtually_sample_distribution(self._distr, samples=samples, *args, 
                                              sample_chunksize=sample_chunksize, **kwargs)
         else:
-            return sample_distribution(self._stats_distribution, samples=samples, *args, **kwargs)
+            return sample_distribution(self._distr, samples=samples, *args, **kwargs)
         
 
-    def __call__(self, *args, samples=1, sample_chunksize=None, **kwargs):        
-        """Return virtually sampled distribution.
-
+    def __call__(self, *args, samples=None, virtual=None, sample_chunksize=None, **kwargs):
+        """Freeze the distribution.
+        
         Parameters
         ----------
         args, kwargs: xarray.DataArray
             The shape parameter(s) for the distribution. Should include all the non-optional arguments,
             may include ``loc`` and ``scale``.
         samples: int, optional
-            Number of random samples (default: 1)
-        sample_chunksize : ints, optional
-            Chunksize of the sample dimension. If given, the number of samples cannot be later changed.
-
+            Number of random samples. 
+        virtual: bool, optional
+            Return virtually sampled distribution?
+        sample_chinksize: ints, optional
+            Chunksize of the sample dimension. If given, the number of samples cannot be later changed. 
+            Used only if `virtual` is True.
+        
         Returns
         -------
-        virtual_samples: xarray.DataArray
-            DataArray wrapping delayed Dask array. Samples obtained by `virtual_samples.values` will be
-            different on each call. Use `xrrandom.change_virtual_samples` or`xrrandom.sample` 
-            to change number of samples.
+        rvs: FrozenScipyStatsWrapper
+            Frozen version of the distribution with shape parameters fixed
         """
-        return self.rvs(virtual=True, sample_chunksize=sample_chunksize)        
 
-# add wrappers for all distributions in the scipy.stats
+        return FrozenScipyDistribution(self, *args, samples=samples, virtual=virtual, sample_chunksize=sample_chunksize, **kwargs)
+
+class FrozenScipyDistribution:
+    """Xarray wrapper for frozen scipy.stats distribution.         
+    
+    It contains the same methods as scipy.stats distribution, such as ``rvs`` to draw
+    random samples.
+
+    Use ``rvs`` with parameter ``virtual=True`` to obtain virtually sampled distribution.
+
+    For the virtual sampling idea look at :py:func`xrrandom.sampling.generate_virtual_samples``
+    """    
+    def __init__(self, distr, *args, samples=None, sample_chunksize=None, virtual=None, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+        self.distr = distr
+        self.samples = samples
+        self.sample_chunksize=sample_chunksize
+        self.virtual = virtual
+
+    def rvs(self, samples=None, virtual=None, sample_chunksize=None):
+        """Sample frozen distribution.
+        
+        Parameters
+        ----------       
+        samples: int, optional
+            Number of random samples (default: 1)
+        virtual: bool, optional
+            Return virtually sampled distribution (default: False)
+        sample_chinksize: ints, optional
+            Chunksize of the sample dimension (default: None). If given, 
+            the number of samples cannot be later changed. Used only if 
+            `virtual` is True.
+        
+        Returns
+        -------
+        rvs: xarray.DataArray
+            Random samples from the given distribution. Standard static array 
+            if virtual is False, otherwise DataArray wrapping delayed Dask 
+            array. In such case samples obtained by `virtual_samples.values` 
+            will be different on each call. Use `xrrandom.change_virtual_samples`
+            or`xrrandom.distributions.sample` to change number of virtual samples.
+        """
+        samples = samples or self.samples or 1
+        virtual = virtual or self.virtual or self.distr._default_virtual
+        sample_chunksize = sample_chunksize or self.sample_chunksize
+
+        return self.distr.rvs(*self.args, samples=samples, virtual=virtual, sample_chunksizes=sample_chunksize, **self.kwargs)
+
+# augment this module by all distributions in the scipy.stats
 for name, distr in stats.__dict__.items():
-    if isinstance(distr, (stats.rv_continuous, stats.rv_discrete)):                    
-        globals()[name] = ScipyStatsWrapper(distr)
+    if isinstance(distr, (stats.rv_continuous, stats.rv_discrete)):
+        globals()[name] = ScipyDistribution(distr)

--- a/xrrandom/stats.py
+++ b/xrrandom/stats.py
@@ -1,11 +1,11 @@
-from types import MethodType
-from functools import partial
 from inspect import signature, Parameter
-import dask.array as da
 import scipy.stats as stats
-import warnings
+import numpy as np
+import xarray as xr
 
-from .scipy_stats_sampling import sample_distribution, virtually_sample_distribution
+from .scipy_stats_sampling import (sample_distribution,
+                                   virtually_sample_distribution,
+                                   _parse_scipy_args, _output_dtypes)
 from .scipy_stats_gen import distribution_kind, distribution_parameters
 
 
@@ -45,19 +45,28 @@ def _update_signature(sig, shape_params, all_pos_or_kw=True, remove_kwargs=False
                     
     return sig.replace(parameters=params)
 
+
 def _wrap_stats_method(stats_distribution, method, all_pos_or_kw = True, remove_kwargs = False,
                        shape_parameters = None, broadcast = False):
     """Return method from scipy distribution with updated signature describing
     shape parameters of the distribution"""
             
     sig = signature(method)
+    parameters = distribution_parameters(stats_distribution)
 
+    # TODO: better way how to distinguish rvs and __call__ from scipy methods
     if 'self' in sig.parameters:
-        def wrapped_method(*args, **kwargs):            
-            return method(*args, **kwargs) 
+
+        def wrapped_method(self, *args, **kwargs):
+            return method(self, *args, **kwargs)
+
     else:
-        def wrapped_method(self, *args, **kwargs):            
-            return method(*args, **kwargs)                
+        output_dtype = _output_dtypes[distribution_kind(stats_distribution)]
+
+        def wrapped_method(self, *args, **kwargs):
+            args = _parse_scipy_args(parameters, *args, **kwargs)
+            args = [xr.DataArray(a) for a in args]
+            return xr.apply_ufunc(method, *args, output_dtypes=[output_dtype])
     
     if shape_parameters is None:
         shape_parameters = list(distribution_parameters(stats_distribution))
@@ -253,6 +262,7 @@ class FrozenScipyBase:
 
         return self.distr.rvs(*self.args, samples=samples, virtual=virtual, sample_chunksizes=sample_chunksize, **self.kwargs)
 
+
 class FrozenScipyContinuous(FrozenScipyBase):    
     def pdf(self, x):
         return self.distr.pdf(x, *self.args, **self.kwargs)
@@ -263,10 +273,10 @@ class FrozenScipyContinuous(FrozenScipyBase):
 
 class FrozenScipyDiscrete(FrozenScipyBase):    
     def pmf(self, k):
-        return self.distr.pmf(x, *self.args, **self.kwargs)
+        return self.distr.pmf(k, *self.args, **self.kwargs)
 
-    def pmf(self, k):
-        return self.distr.logpmf(x, *self.args, **self.kwargs)
+    def logpmf(self, k):
+        return self.distr.logpmf(k, *self.args, **self.kwargs)
 
 
 def _register_rv(name, distr):


### PR DESCRIPTION
This PR adds module `distributions` which treats the virtual samples as a representation of the distribution itself. Now the user can do something like:
```
gamma_distr = distributions.gamma(a=5, loc=5)
samples = sample(gamma_distr, 1000)
more_samples = sample(gamma_distr, 100)
```

To sample the distribution right away one can use `sample=True`: 
```
distributions.normal(scale=5, samples=100, sample=True) # -> 100 samples
```

This feels quite intuitive to me. @smartass101, what do you think? If you agree with this approach, I'll add shortcuts to more distributions before merging so that the user does not need to call `distributions.from_scipy` so often.